### PR TITLE
Add standalone ChatGPT relay webapp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Kopieer dit bestand naar .env en vul je eigen OpenAI-sleutel in.
+OPENAI_API_KEY=plak-hier-je-openai-sleutel
+# OPENAI_MODEL=gpt-4o-mini
+# PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# chatgpt-codex-projects
+# ChatGPT op afstand
+
+Een compacte Node.js-toepassing waarmee je via een eigen OpenAI API-sleutel een privé webinterface voor ChatGPT kunt hosten. De webapp bestaat uit een eenvoudige backend (zonder externe afhankelijkheden) die verzoeken doorstuurt naar de OpenAI Chat Completions API en een moderne frontend waar je het gesprek beheert.
+
+## Functies
+
+- 📡 **Eigen proxy** – verstuur gesprekken naar OpenAI via jouw server, zonder dat de sleutel in de browser terechtkomt.
+- 💬 **Intuïtieve chatinterface** – gespreksoverzicht, systeembericht, temperatuurregeling en statusfeedback.
+- 🔒 **Lokale opslag** – het volledige gesprek en je instellingen blijven in de browser (localStorage).
+- ⚙️ **Aanpasbaar model** – kies optioneel een ander model via de omgeving (`OPENAI_MODEL`).
+
+## Aan de slag
+
+### Vereisten
+
+- Node.js 18 of hoger
+- Een geldige OpenAI API-sleutel met toegang tot het gewenste chatmodel
+
+### Installatie
+
+1. Kopieer `.env.example` naar `.env` en vul je API-sleutel in:
+
+   ```bash
+   cp .env.example .env
+   # Bewerk .env en voeg je sleutel toe
+   ```
+
+2. Start de server:
+
+   ```bash
+   npm start
+   ```
+
+3. Open je browser en ga naar <http://localhost:3000> om te beginnen met chatten.
+
+### Beschikbare scripts
+
+- `npm start` – start de HTTP-server.
+- `npm run lint` – controleert de server op syntaxisfouten (`node --check`).
+
+## Omgevingsvariabelen
+
+| Variabele        | Beschrijving                                                                 | Standaard         |
+| ---------------- | ----------------------------------------------------------------------------- | ----------------- |
+| `OPENAI_API_KEY` | Vereist. Je persoonlijke OpenAI sleutel.                                      | –                 |
+| `OPENAI_MODEL`   | Optioneel. Het model dat je wilt gebruiken (bijv. `gpt-4o-mini`).             | `gpt-3.5-turbo`   |
+| `PORT`           | Optioneel. Poort waarop de server luistert.                                   | `3000`            |
+
+> De server laadt automatisch variabelen uit een `.env`-bestand in de hoofdmap als dat aanwezig is.
+
+## Hoe het werkt
+
+- De backend accepteert POST-verzoeken op `/api/chat` met een `messages`-array in het OpenAI formaat.
+- Het verzoek wordt doorgestuurd naar `https://api.openai.com/v1/chat/completions`.
+- De frontend bewaart het gesprek lokaal, zodat je pagina verversen zonder historie te verliezen.
+
+## Veiligheidsnotities
+
+- Houd je `.env`-bestand privé. Deel je API-sleutel nooit client-side.
+- Overweeg extra authenticatie wanneer je de server publiekelijk toegankelijk maakt.
+
+Veel chatplezier!

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "chatgpt-codex-projects",
+  "version": "1.0.0",
+  "description": "Een lichtgewicht webapplicatie om ChatGPT op afstand te gebruiken via een eigen API-sleutel.",
+  "main": "src/server.js",
+  "type": "commonjs",
+  "private": true,
+  "scripts": {
+    "start": "node src/server.js",
+    "lint": "node --check src/server.js"
+  },
+  "keywords": [
+    "chatgpt",
+    "openai",
+    "proxy",
+    "node"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,277 @@
+const STORAGE_KEY = 'remote-chatgpt-state-v1';
+const DEFAULT_SYSTEM_PROMPT =
+  'Je bent ChatGPT, een behulpzame assistent. Beantwoord vragen duidelijk en in het Nederlands tenzij anders gevraagd.';
+
+const chatLog = document.querySelector('#chat-log');
+const chatForm = document.querySelector('#chat-form');
+const messageInput = document.querySelector('#user-message');
+const statusLine = document.querySelector('#status');
+const systemInput = document.querySelector('#system-message');
+const temperatureInput = document.querySelector('#temperature');
+const temperatureValue = document.querySelector('#temperature-value');
+const clearButton = document.querySelector('#clear-chat');
+const submitButton = chatForm.querySelector('button[type="submit"]');
+
+const state = {
+  conversation: [],
+  loading: false,
+};
+
+init();
+
+function init() {
+  restoreState();
+  renderConversation();
+  updateTemperatureLabel();
+  setStatus('Klaar om te chatten.');
+}
+
+function restoreState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      systemInput.value = DEFAULT_SYSTEM_PROMPT;
+      syncSystemMessage();
+      return;
+    }
+
+    const parsed = JSON.parse(raw);
+    const systemMessage = typeof parsed.system === 'string' ? parsed.system : DEFAULT_SYSTEM_PROMPT;
+    systemInput.value = systemMessage;
+
+    const savedConversation = Array.isArray(parsed.conversation) ? parsed.conversation : [];
+    state.conversation = savedConversation
+      .filter((message) => isValidMessage(message))
+      .map((message) => ({ role: message.role, content: message.content }));
+
+    if (!state.conversation.some((message) => message.role === 'system') && systemMessage.trim()) {
+      state.conversation.unshift({ role: 'system', content: systemMessage.trim() });
+    } else {
+      syncSystemMessage();
+    }
+
+    if (typeof parsed.temperature === 'string' || typeof parsed.temperature === 'number') {
+      const tempValue = Number(parsed.temperature);
+      if (!Number.isNaN(tempValue)) {
+        temperatureInput.value = String(Math.min(Math.max(tempValue, 0), 1));
+      }
+    }
+  } catch (error) {
+    console.warn('Kon opgeslagen gesprek niet laden:', error);
+    systemInput.value = DEFAULT_SYSTEM_PROMPT;
+    syncSystemMessage();
+  }
+}
+
+function isValidMessage(message) {
+  return message && typeof message.role === 'string' && typeof message.content === 'string';
+}
+
+function persistState() {
+  try {
+    const data = {
+      system: systemInput.value,
+      temperature: temperatureInput.value,
+      conversation: state.conversation.map((message) => ({
+        role: message.role,
+        content: message.content,
+      })),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch (error) {
+    console.warn('Kon gesprek niet opslaan:', error);
+  }
+}
+
+function renderConversation() {
+  chatLog.innerHTML = '';
+  if (state.conversation.length === 0) {
+    const emptyMessage = document.createElement('p');
+    emptyMessage.className = 'chat__placeholder';
+    emptyMessage.textContent = 'Nog geen berichten. Stel een vraag om te beginnen.';
+    chatLog.append(emptyMessage);
+    persistState();
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  state.conversation.forEach((message) => {
+    fragment.append(createMessageElement(message));
+  });
+
+  chatLog.append(fragment);
+  chatLog.scrollTop = chatLog.scrollHeight;
+  persistState();
+}
+
+function createMessageElement(message) {
+  const article = document.createElement('article');
+  article.className = `message message--${message.role}`;
+
+  const heading = document.createElement('header');
+  heading.className = 'message__role';
+  heading.textContent = roleLabel(message.role);
+  article.append(heading);
+
+  const content = document.createElement('div');
+  content.className = 'message__content';
+
+  const blocks = message.content.split(/\n{2,}/);
+  blocks.forEach((block) => {
+    const paragraph = document.createElement('p');
+    block.split(/\n/).forEach((line, index) => {
+      if (index > 0) {
+        paragraph.append(document.createElement('br'));
+      }
+      paragraph.append(document.createTextNode(line));
+    });
+    content.append(paragraph);
+  });
+
+  article.append(content);
+  return article;
+}
+
+function roleLabel(role) {
+  switch (role) {
+    case 'system':
+      return 'Systeem';
+    case 'assistant':
+      return 'ChatGPT';
+    case 'user':
+      return 'Jij';
+    default:
+      return role;
+  }
+}
+
+chatForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  if (state.loading) {
+    return;
+  }
+
+  const userText = messageInput.value.trim();
+  if (!userText) {
+    setStatus('Typ eerst een bericht.', 'warning');
+    return;
+  }
+
+  syncSystemMessage();
+  const userMessage = { role: 'user', content: userText };
+  state.conversation.push(userMessage);
+  messageInput.value = '';
+  renderConversation();
+  await requestCompletion(userMessage);
+});
+
+clearButton.addEventListener('click', () => {
+  if (!state.conversation.length) {
+    return;
+  }
+
+  const systemText = systemInput.value.trim();
+  state.conversation = systemText ? [{ role: 'system', content: systemText }] : [];
+  renderConversation();
+  setStatus('Gesprek geleegd.');
+});
+
+systemInput.addEventListener('change', () => {
+  syncSystemMessage();
+  renderConversation();
+  setStatus('Systeembericht bijgewerkt.');
+});
+
+temperatureInput.addEventListener('input', () => {
+  updateTemperatureLabel();
+  persistState();
+});
+
+async function requestCompletion(lastUserMessage) {
+  setLoading(true);
+  setStatus('Antwoord opvragen...');
+
+  const payload = {
+    messages: state.conversation.map((message) => ({ role: message.role, content: message.content })),
+  };
+
+  const temperature = Number(temperatureInput.value);
+  if (!Number.isNaN(temperature)) {
+    payload.temperature = temperature;
+  }
+
+  try {
+    const response = await fetch('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data?.error || 'Onbekende fout van de server.');
+    }
+
+    const answer = typeof data.message === 'string' && data.message.trim() ? data.message.trim() : '(Geen inhoud in antwoord)';
+    state.conversation.push({ role: 'assistant', content: answer });
+    renderConversation();
+
+    if (data.usage) {
+      const { prompt_tokens: promptTokens, completion_tokens: completionTokens, total_tokens: totalTokens } = data.usage;
+      const parts = [
+        typeof promptTokens === 'number' ? `prompt: ${promptTokens}` : null,
+        typeof completionTokens === 'number' ? `antwoord: ${completionTokens}` : null,
+        typeof totalTokens === 'number' ? `totaal: ${totalTokens}` : null,
+      ].filter(Boolean);
+      setStatus(`Antwoord ontvangen (${parts.join(', ')}).`);
+    } else {
+      setStatus('Antwoord ontvangen.');
+    }
+  } catch (error) {
+    console.error('Fout bij het ophalen van antwoord:', error);
+    const index = state.conversation.lastIndexOf(lastUserMessage);
+    if (index !== -1) {
+      state.conversation.splice(index, 1);
+    }
+    renderConversation();
+    messageInput.value = lastUserMessage.content;
+    messageInput.focus();
+    setStatus(error.message, 'error');
+  } finally {
+    setLoading(false);
+  }
+}
+
+function syncSystemMessage() {
+  const systemText = systemInput.value.trim();
+  const index = state.conversation.findIndex((message) => message.role === 'system');
+  if (!systemText && index !== -1) {
+    state.conversation.splice(index, 1);
+    return;
+  }
+
+  if (systemText && index === -1) {
+    state.conversation.unshift({ role: 'system', content: systemText });
+  } else if (systemText) {
+    state.conversation[index].content = systemText;
+  }
+}
+
+function updateTemperatureLabel() {
+  const value = Number(temperatureInput.value);
+  temperatureValue.textContent = value.toFixed(1);
+}
+
+function setLoading(isLoading) {
+  state.loading = isLoading;
+  submitButton.disabled = isLoading;
+  messageInput.disabled = isLoading;
+  chatForm.classList.toggle('chat__form--loading', isLoading);
+}
+
+function setStatus(message, type = 'info') {
+  statusLine.textContent = message;
+  statusLine.dataset.type = type;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ChatGPT op afstand</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="top-bar">
+      <div class="container">
+        <h1>ChatGPT op afstand</h1>
+        <p>
+          Gebruik deze eenvoudige interface om via je eigen OpenAI-sleutel gesprekken te voeren met ChatGPT.
+          Je volledige gesprek blijft lokaal in je browser opgeslagen.
+        </p>
+      </div>
+    </header>
+    <main class="container">
+      <section class="settings" aria-labelledby="settings-title">
+        <h2 id="settings-title">Gespreksinstellingen</h2>
+        <div class="field">
+          <label class="field__label" for="system-message">Systeembericht</label>
+          <textarea
+            id="system-message"
+            class="field__textarea"
+            rows="3"
+            placeholder="Beschrijf de rol of toon van ChatGPT"
+          ></textarea>
+          <p class="field__hint">
+            Dit bericht bepaalt de context van het gesprek. Laat het leeg voor de standaardinstructie.
+          </p>
+        </div>
+        <div class="field field--inline">
+          <label class="field__label" for="temperature">Creativiteit (<span id="temperature-value">0.7</span>)</label>
+          <input
+            id="temperature"
+            type="range"
+            min="0"
+            max="1"
+            step="0.1"
+            value="0.7"
+            aria-describedby="temperature-hint"
+          />
+          <p class="field__hint" id="temperature-hint">
+            Een lagere waarde maakt de antwoorden gerichter, een hogere waarde creatiever.
+          </p>
+        </div>
+      </section>
+
+      <section class="chat" aria-labelledby="chat-title">
+        <div class="chat__header">
+          <h2 id="chat-title">Gesprek</h2>
+          <button type="button" id="clear-chat" class="ghost-button">Leeg gesprek</button>
+        </div>
+        <div id="chat-log" class="chat__log" aria-live="polite" aria-atomic="false"></div>
+        <form id="chat-form" class="chat__form">
+          <label class="field__label" for="user-message">Je bericht</label>
+          <textarea
+            id="user-message"
+            class="field__textarea"
+            rows="4"
+            placeholder="Stel een vraag of geef een instructie"
+            required
+          ></textarea>
+          <div class="form-actions">
+            <button type="submit" class="primary-button">Verstuur</button>
+          </div>
+          <p id="status" class="status" role="status" aria-live="polite"></p>
+        </form>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container">
+        <p>
+          Vergeet niet om je <code>OPENAI_API_KEY</code> als omgevingsvariabele op de server in te stellen voordat je de applicatie start.
+        </p>
+      </div>
+    </footer>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,333 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --bg: #f4f6fb;
+  --bg-elevated: #ffffff;
+  --bg-muted: #e9edf5;
+  --border: rgba(15, 23, 42, 0.12);
+  --border-strong: rgba(15, 23, 42, 0.24);
+  --text: #0f172a;
+  --text-muted: #475569;
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --warning: #d97706;
+  --error: #dc2626;
+  --shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f172a;
+    --bg-elevated: #111c33;
+    --bg-muted: #1e293b;
+    --border: rgba(148, 163, 184, 0.24);
+    --border-strong: rgba(148, 163, 184, 0.4);
+    --text: #e2e8f0;
+    --text-muted: #cbd5f5;
+    --accent: #60a5fa;
+    --accent-strong: #3b82f6;
+    --shadow: 0 16px 36px rgba(15, 23, 42, 0.35);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top right, rgba(37, 99, 235, 0.08), transparent 55%), var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+h1,
+h2,
+h3 {
+  color: var(--text);
+  font-weight: 700;
+  margin: 0;
+}
+
+p {
+  margin: 0 0 0.75rem;
+  color: var(--text-muted);
+}
+
+.container {
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.top-bar {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.8), rgba(59, 130, 246, 0.9));
+  color: white;
+  padding: 2.75rem 0 2rem;
+  box-shadow: var(--shadow);
+}
+
+.top-bar h1 {
+  color: inherit;
+  font-size: clamp(1.9rem, 2.5vw, 2.4rem);
+  margin-bottom: 0.5rem;
+}
+
+.top-bar p {
+  color: rgba(255, 255, 255, 0.9);
+  max-width: 48ch;
+}
+
+main.container {
+  flex: 1;
+  width: min(960px, 100%);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  gap: 2rem;
+  padding-top: 2.5rem;
+  padding-bottom: 3rem;
+}
+
+.settings,
+.chat {
+  background: var(--bg-elevated);
+  border-radius: 20px;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.settings {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field--inline {
+  gap: 0.35rem;
+}
+
+.field__label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.field__textarea {
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  padding: 0.875rem 1rem;
+  font: inherit;
+  resize: vertical;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 3rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field__textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.field__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+input[type='range'] {
+  width: 100%;
+}
+
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.chat__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.chat__log {
+  min-height: 320px;
+  max-height: 55vh;
+  overflow-y: auto;
+  padding: 1.25rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--bg-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chat__placeholder {
+  margin: auto;
+  text-align: center;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.message {
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid transparent;
+  background: white;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  .message {
+    background: rgba(15, 23, 42, 0.6);
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.45);
+  }
+}
+
+.message--user {
+  align-self: flex-end;
+  background: rgba(37, 99, 235, 0.1);
+  border-color: rgba(37, 99, 235, 0.25);
+}
+
+.message--assistant {
+  border-color: rgba(15, 23, 42, 0.08);
+}
+
+.message--system {
+  align-self: center;
+  background: rgba(148, 163, 184, 0.25);
+  border-color: rgba(148, 163, 184, 0.5);
+}
+
+.message__role {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.5rem;
+  color: var(--text-muted);
+}
+
+.message__content p {
+  margin: 0 0 0.75rem;
+  line-height: 1.6;
+}
+
+.message__content p:last-child {
+  margin-bottom: 0;
+}
+
+.chat__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chat__form--loading {
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.primary-button,
+.ghost-button {
+  font: inherit;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.primary-button {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.25);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  background: var(--accent-strong);
+}
+
+.primary-button:active {
+  transform: translateY(0);
+}
+
+.ghost-button {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.ghost-button:hover {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.status {
+  min-height: 1.2rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.status[data-type='error'] {
+  color: var(--error);
+}
+
+.status[data-type='warning'] {
+  color: var(--warning);
+}
+
+.footer {
+  padding: 1.5rem 0 2.5rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.footer code {
+  background: rgba(15, 23, 42, 0.07);
+  padding: 0.15rem 0.4rem;
+  border-radius: 6px;
+}
+
+@media (max-width: 900px) {
+  main.container {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .settings,
+  .chat {
+    padding: 1.5rem;
+  }
+
+  .chat__log {
+    min-height: 260px;
+  }
+
+  .form-actions {
+    justify-content: stretch;
+  }
+
+  .primary-button,
+  .ghost-button {
+    width: 100%;
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,250 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const publicDir = path.join(__dirname, '..', 'public');
+
+loadEnvFile();
+
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || 'gpt-3.5-turbo';
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (req.method === 'POST' && url.pathname === '/api/chat') {
+      await handleChatRequest(req, res);
+      return;
+    }
+
+    if (req.method === 'GET') {
+      await serveStaticFile(url.pathname, res);
+      return;
+    }
+
+    res.writeHead(405, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Method not allowed' }));
+  } catch (error) {
+    console.error('Unexpected server error', error);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Internal server error' }));
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`ChatGPT relay server listening on http://localhost:${PORT}`);
+});
+
+function loadEnvFile() {
+  const envPath = path.join(__dirname, '..', '.env');
+  try {
+    const data = fs.readFileSync(envPath, 'utf8');
+    data.split(/\r?\n/).forEach((line) => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        return;
+      }
+
+      const equalsIndex = trimmed.indexOf('=');
+      if (equalsIndex === -1) {
+        return;
+      }
+
+      const key = trimmed.slice(0, equalsIndex).trim();
+      const value = trimmed.slice(equalsIndex + 1).trim().replace(/^['"]|['"]$/g, '');
+      if (!(key in process.env)) {
+        process.env[key] = value;
+      }
+    });
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      console.warn('Could not read .env file:', error.message);
+    }
+  }
+}
+
+async function handleChatRequest(req, res) {
+  if (!process.env.OPENAI_API_KEY) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'OPENAI_API_KEY is not configured on the server.' }));
+    return;
+  }
+
+  let body = '';
+  for await (const chunk of req) {
+    body += chunk;
+    if (body.length > 1e6) {
+      res.writeHead(413, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Request body too large' }));
+      req.destroy();
+      return;
+    }
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(body || '{}');
+  } catch (error) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Request body must be valid JSON.' }));
+    return;
+  }
+
+  const { messages, temperature, max_tokens: maxTokens } = payload || {};
+  if (!Array.isArray(messages) || messages.length === 0) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'The "messages" array is required.' }));
+    return;
+  }
+
+  const sanitizedMessages = [];
+  for (const message of messages) {
+    if (!message || typeof message.role !== 'string' || typeof message.content !== 'string') {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Each message must include a role and content string.' }));
+      return;
+    }
+
+    sanitizedMessages.push({
+      role: message.role,
+      content: message.content,
+    });
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 60000);
+
+    const apiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: DEFAULT_MODEL,
+        messages: sanitizedMessages,
+        temperature: typeof temperature === 'number' ? temperature : 0.7,
+        max_tokens: typeof maxTokens === 'number' ? maxTokens : undefined,
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    const responseBody = await apiResponse.text();
+    if (!apiResponse.ok) {
+      let errorMessage = 'Failed to retrieve a response from OpenAI.';
+      try {
+        const parsed = JSON.parse(responseBody);
+        if (parsed?.error?.message) {
+          errorMessage = parsed.error.message;
+        }
+      } catch (error) {
+        // ignore JSON parse errors
+      }
+      console.error('OpenAI API error:', apiResponse.status, responseBody);
+      res.writeHead(apiResponse.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: errorMessage }));
+      return;
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(responseBody);
+    } catch (error) {
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Invalid response format from OpenAI.' }));
+      return;
+    }
+
+    const assistantMessage = parsed?.choices?.[0]?.message?.content || '';
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        message: assistantMessage,
+        usage: parsed?.usage ?? null,
+      })
+    );
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      res.writeHead(504, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'The OpenAI request timed out.' }));
+      return;
+    }
+
+    console.error('Error contacting OpenAI:', error);
+    res.writeHead(502, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Unable to complete the request to OpenAI.' }));
+  }
+}
+
+async function serveStaticFile(requestPath, res) {
+  const decodedPath = decodeURIComponent(requestPath);
+  const relativePath = decodedPath === '/' ? 'index.html' : decodedPath.replace(/^\/+/, '');
+  const absolutePath = path.join(publicDir, relativePath);
+  if (!absolutePath.startsWith(publicDir)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain' });
+    res.end('Forbidden');
+    return;
+  }
+
+  try {
+    const stat = await fs.promises.stat(absolutePath);
+    if (stat.isDirectory()) {
+      await streamFile(path.join(absolutePath, 'index.html'), res);
+      return;
+    }
+    await streamFile(absolutePath, res);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not Found');
+    } else {
+      console.error('Static file error:', error);
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Internal Server Error');
+    }
+  }
+}
+
+async function streamFile(filePath, res) {
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = getContentType(ext);
+  res.writeHead(200, { 'Content-Type': contentType });
+  const stream = fs.createReadStream(filePath);
+  stream.pipe(res);
+  stream.on('error', (error) => {
+    console.error('Stream error:', error);
+    if (!res.headersSent) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+    }
+    res.end('Internal Server Error');
+  });
+}
+
+function getContentType(ext) {
+  switch (ext) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'application/javascript; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.svg':
+      return 'image/svg+xml';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.ico':
+      return 'image/x-icon';
+    default:
+      return 'application/octet-stream';
+  }
+}


### PR DESCRIPTION
## Summary
- build a dependency-free Node.js server that proxies /api/chat requests to OpenAI and serves static assets
- add a modern Dutch single-page chat interface with system prompt, temperature control, persistence and status feedback
- document setup, environment variables and usage instructions for running the remote ChatGPT client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd944aecfc83328e2ebee161114e70